### PR TITLE
moving xrange to range for python 3 support

### DIFF
--- a/timezones/zones.py
+++ b/timezones/zones.py
@@ -13,5 +13,5 @@ for tz in pytz.common_timezones:
     ofs = now.strftime("%z")
     PRETTY_TIMEZONE_CHOICES.append((int(ofs), tz, "(GMT%s) %s" % (ofs, tz)))
 PRETTY_TIMEZONE_CHOICES.sort()
-for i in xrange(len(PRETTY_TIMEZONE_CHOICES)):
+for i in range(len(PRETTY_TIMEZONE_CHOICES)):
     PRETTY_TIMEZONE_CHOICES[i] = PRETTY_TIMEZONE_CHOICES[i][1:]


### PR DESCRIPTION
Proper fix is to use `six`, but this will do in a pinch.